### PR TITLE
Fixed demo missing dependencies

### DIFF
--- a/modules/dcb_demo/dcb_demo.info.yml
+++ b/modules/dcb_demo/dcb_demo.info.yml
@@ -4,7 +4,10 @@ dependencies:
   - dcb:dcb
   - drupal:field
   - drupal:field_ui
+  - drupal:menu_ui
   - drupal:node
+  - drupal:options
+  - drupal:path
 hidden: false
 name: DCB Demo
 package: DCB


### PR DESCRIPTION
Receive error upon attempting to install demo:

> Unable to install DCB Demo due to unmet dependencies: core.entity_form_display.node.dcb_page.default (path), core.entity_view_display.dcb_component.heading.default (options), node.type.dcb_page (menu_ui)